### PR TITLE
Reimplementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,144 +1,88 @@
 'use strict';
 
-function Mixinable () {}
-
-Mixinable.mixin = function mixin () {
-  var mixin = normalize([this.__mixin__].concat(
-    argsToArray.apply(null, arguments)
-  ));
-  var extension = apply(mixin);
-  var parent = this;
-  var child = (
-    extension.hasOwnProperty('constructor')
-    ? extension.constructor
-    : function () {
-      if (!(this instanceof child)) {
-        var args = argsToArray.apply(null, arguments);
-        return new (child.bind.apply(child, [child].concat(args)))();
-      }
-      parent.apply(this, arguments);
-    }
-  );
-  delete mixin.constructor;
-  return Object.assign(child, parent, {
-    __mixin__: mixin,
-    __super__: parent.prototype,
-    prototype: Object.assign(
-      Object.create(parent.prototype),
-      extension,
-      {
-        constructor: child
-      }
-    )
+module.exports = exports = function define (definition) {
+  var keys = Object.keys(definition || {}).filter(function (key) {
+    return isFunction(definition[key]);
   });
-};
-
-module.exports = Object.assign(
-  Mixinable.mixin.bind(Mixinable),
-  {
-    override: wrap(getLastFunction),
-    parallel: wrap(function parallel () {
-      var functions = filterFunctions.apply(null, arguments);
-      return function runInParallel () {
-        var args = argsToArray.apply(null, arguments);
-        var results = functions.map(function (fn) {
-          return fn.apply(this, args);
-        }.bind(this));
-        return (
-          results.filter(isPromise).length
-          ? Promise.all(results)
-          : results
-        );
-      };
-    }),
-    pipe: wrap(function pipe () {
-      var functions = filterFunctions.apply(null, arguments);
-      return function runAsPipe () {
-        var args = argsToArray.apply(null, arguments);
-        return functions.reduce(
-          function (result, fn) {
-            if (isPromise(result)) {
-              return result.then(function (value) {
-                return fn.apply(this, [value].concat(args));
-              }.bind(this));
-            }
-            return fn.apply(this, [result].concat(args));
-          }.bind(this),
-          args.shift()
-        );
-      };
-    }),
-    sequence: wrap(function sequence () {
-      var functions = filterFunctions.apply(null, arguments);
-      return function runInSequence () {
-        var args = argsToArray.apply(null, arguments);
-        return functions.reduce(
-          function (result, fn) {
-            if (isPromise(result)) {
-              return result.then(fn.apply.bind(fn, this, args));
-            }
-            return fn.apply(this, args);
-          }.bind(this),
-          null
-        );
-      };
-    })
-  }
-);
-
-// mixin definition handling
-
-function normalize (mixins) {
-  return mixins.reduce(function (result, mixin) {
-    if (!mixin) return result;
-    return Object.keys(mixin).reduce(function (result, key) {
-      result[key] = (
-        result.hasOwnProperty(key)
-        ? result[key]
-        : {
-          strategy: getLastFunction,
-          implementation: []
+  var mixinable = createClass(
+    keys.reduce(function (result, key) {
+      if (key === 'constructor') {
+        result[key] = definition[key];
+      } else {
+        result[key] = function () {
+          var args = argsToArray.apply(null, arguments);
+          var functions = this.__implementations__[key];
+          return definition[key].apply(this, [functions].concat(args));
+        };
+      }
+      return result;
+    }, {})
+  );
+  return function mixin () {
+    var mixins = argsToArray.apply(null, arguments).map(createClass);
+    return function create () {
+      var args = argsToArray.apply(null, arguments);
+      var mixinstances = mixins.map(function (mixin) {
+        return new (mixin.bind.apply(mixin, [mixin].concat(args)))();
+      });
+      return Object.defineProperty(
+        new (mixinable.bind.apply(mixinable, [mixinable].concat(args)))(),
+        '__implementations__',
+        {
+          value: keys.reduce(function (result, key) {
+            result[key] = mixinstances
+              .filter(function (mixinstance) {
+                return isFunction(mixinstance[key]);
+              })
+              .map(function (mixinstance) {
+                return mixinstance[key].bind(mixinstance);
+              });
+            return result;
+          }, {})
         }
       );
-      result[key].strategy = (
-        isFunction(mixin[key].strategy)
-        ? mixin[key].strategy
-        : result[key].strategy
-      );
-      result[key].implementation = (
-        result[key].implementation
-        .concat(
-          mixin[key].implementation ||
-          mixin[key]
-        )
-        .filter(isFunction)
-      );
-      return result;
-    }, result);
-  }, {});
-}
-
-function apply (mixin) {
-  return Object.keys(mixin).reduce(function (result, key) {
-    var definition = mixin[key];
-    result[key] = definition.strategy.apply(
-      null,
-      definition.implementation
-    );
-    return result;
-  }, {});
-}
-
-function wrap (strategy) {
-  return function () {
-    return {
-      strategy: strategy,
-      implementation: argsToArray.apply(null, arguments)
     };
   };
-}
+};
 
-// helpers
+exports.parallel = function parallel (functions) {
+  var args = argsToArray.apply(null, arguments).slice(1);
+  var results = functions.map(function (fn) {
+    return fn.apply(null, args);
+  });
+  return (
+    results.filter(isPromise).length
+    ? Promise.all(results)
+    : results
+  );
+};
+
+exports.pipe = function pipe (functions) {
+  var args = argsToArray.apply(null, arguments).slice(1);
+  return functions.reduce(
+    function (result, fn) {
+      if (isPromise(result)) {
+        return result.then(function (value) {
+          return fn.apply(null, [value].concat(args));
+        });
+      }
+      return fn.apply(null, [result].concat(args));
+    },
+    args.shift()
+  );
+};
+
+function createClass (_prototype) {
+  var prototype = Object.assign({}, _prototype);
+  var constructor = function () {};
+  if (prototype.hasOwnProperty('constructor')) {
+    constructor = prototype.constructor;
+  } else {
+    prototype.constructor = constructor;
+  }
+  constructor.prototype = prototype;
+  return constructor;
+}
 
 function argsToArray () {
   var args = new Array(arguments.length);
@@ -146,14 +90,6 @@ function argsToArray () {
     args[i] = arguments[i];
   }
   return args;
-}
-
-function getLastFunction () {
-  return filterFunctions.apply(null, arguments).pop();
-}
-
-function filterFunctions () {
-  return argsToArray.apply(null, arguments).filter(isFunction);
 }
 
 function isFunction (obj) {


### PR DESCRIPTION
Singnificantly simplify implementation, have mixins run in their own `this`-context.
Eliminate all traces of classical (constructor based) inheritance.